### PR TITLE
Proxy file channel target to make instance check in `FileChannelImpl#…

### DIFF
--- a/tape/src/main/java/com/squareup/tape2/QueueFile.java
+++ b/tape/src/main/java/com/squareup/tape2/QueueFile.java
@@ -459,7 +459,7 @@ public final class QueueFile implements Closeable, Iterable<byte[]> {
       FileChannel channel = raf.getChannel();
       channel.position(fileLength); // destination position
       count = endOfLastElement - headerLength;
-      if (channel.transferTo(headerLength, count, channel) != count) {
+      if (channel.transferTo(headerLength, count, new WritableByteChannelProxy(channel)) != count) {
         throw new AssertionError("Copied insufficient number of bytes!");
       }
     }

--- a/tape/src/main/java/com/squareup/tape2/WritableByteChannelProxy.java
+++ b/tape/src/main/java/com/squareup/tape2/WritableByteChannelProxy.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2020 iterate GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.tape2;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
+import java.nio.channels.WritableByteChannel;
+
+public class WritableByteChannelProxy implements WritableByteChannel {
+
+    private final WritableByteChannel writable;
+
+    public WritableByteChannelProxy(FileChannel proxy) {
+        this.writable = proxy;
+    }
+
+    @Override
+    public int write(ByteBuffer src) throws IOException {
+        return writable.write(src);
+    }
+
+    @Override
+    public boolean isOpen() {
+        return writable.isOpen();
+    }
+
+    @Override
+    public void close() throws IOException {
+        writable.close();
+    }
+}


### PR DESCRIPTION
…transferToTrustedChannel` fail and pass through alternate implementation `FileChannelImpl#transferToArbitraryChannel`. The former implementation blocks in when running on Apple Silicon both in Rosetta2 with x86_64 runtime and aarch64.